### PR TITLE
add link do documentation

### DIFF
--- a/lib/rules/assign-selector-to-variable.js
+++ b/lib/rules/assign-selector-to-variable.js
@@ -4,6 +4,10 @@ const { VariableDeclarator } = require('../ast/VariableDeclarator');
 
 const meta = {
   type: 'suggestion',
+  docs: {
+    url:
+      "https://github.com/palortoff/eslint-plugin-redux-reselect#redux-reselectassign-selector-to-variable",
+  },
 };
 
 const create = ({ report }) => ({

--- a/lib/rules/format-selector-name.js
+++ b/lib/rules/format-selector-name.js
@@ -4,6 +4,10 @@ const { Identifier } = require('../ast/Identifier');
 
 const meta = {
   type: 'suggestion',
+  docs: {
+    url:
+      "https://github.com/viktor-ku/eslint-plugin-redux-reselect#redux-reselectformat-selector-name",
+  },
 };
 
 const create = ({ report }) => ({

--- a/lib/rules/prefer-selector-ref.js
+++ b/lib/rules/prefer-selector-ref.js
@@ -8,6 +8,10 @@ const meta = {
   messages: {
     preferRef: 'Selector reference expected, {{ type }} found',
   },
+  docs: {
+    url:
+      "https://github.com/palortoff/eslint-plugin-redux-reselect#redux-reselectprefer-selector-ref",
+  },
 };
 
 const create = ({ report }) => ({

--- a/lib/rules/selector-args-type.js
+++ b/lib/rules/selector-args-type.js
@@ -5,6 +5,10 @@ const { ArrowFunctionExpression } = require('../ast/ArrowFunctionExpression');
 
 const meta = {
   type: 'suggestion',
+  docs: {
+    url:
+      "https://github.com/palortoff/eslint-plugin-redux-reselect#redux-reselectselector-args-type",
+  },
 };
 
 const create = ({ report, options }) => ({


### PR DESCRIPTION
VSCode's eslint plugin provides a tooltip containing the link to the rules documentation. 